### PR TITLE
perf: use fflate `zip` (sync) for web worker, instead of `zipAsync`

### DIFF
--- a/packages/excel-builder-vanilla/src/excel-builder.ts
+++ b/packages/excel-builder-vanilla/src/excel-builder.ts
@@ -1,4 +1,4 @@
-import { ZipOptions, strToU8, zipSync } from 'fflate';
+import { ZipOptions, strToU8, zip } from 'fflate';
 
 import { Workbook } from './Excel/Workbook';
 // import { WorkbookWorker } from './Worker';
@@ -32,22 +32,40 @@ export class ExcelBuilder {
    * @param {Object} options - fflate options to modify how the zip is created.
    * @returns {Promise}
    */
-  createFile<T extends 'Blob' | 'Uint8Array' = 'Blob'>(workbook: Workbook, outputType?: T, options?: ZipOptions) {
+  createFile<T extends 'Blob' | 'Uint8Array' = 'Blob'>(
+    workbook: Workbook,
+    outputType?: T,
+    options?: ZipOptions,
+  ): Promise<InferOutputByType<T>> {
     const zipObj: { [name: string]: Uint8Array } = {};
 
-    return workbook.generateFiles().then(files => {
-      for (const [path, content] of Object.entries(files)) {
-        zipObj[path.substr(1)] = strToU8(content);
-      }
+    return new Promise((resolve, reject) => {
+      workbook.generateFiles().then(files => {
+        for (const [path, content] of Object.entries(files)) {
+          zipObj[path.substr(1)] = strToU8(content);
+        }
 
-      switch (outputType) {
-        case 'Uint8Array':
-          return zipSync(zipObj, options) as InferOutputByType<T>;
-        // biome-ignore lint: prefering to be explicit
-        case 'Blob':
-        default:
-          return new Blob([zipSync(zipObj, options)], { type: 'base64' }) as InferOutputByType<T>;
-      }
+        switch (outputType) {
+          case 'Uint8Array':
+            return zip(zipObj, options || {}, (err, data) => {
+              if (err) {
+                reject(err);
+                return;
+              }
+              resolve(data as InferOutputByType<T>);
+            });
+          // biome-ignore lint: prefering to be explicit
+          case 'Blob':
+          default:
+            return zip(zipObj, options || {}, (err, data) => {
+              if (err) {
+                reject(err);
+                return;
+              }
+              resolve(new Blob([data], { type: 'base64' }) as InferOutputByType<T>);
+            });
+        }
+      });
     });
   }
 }


### PR DESCRIPTION
- the `fflate` project recommends using `zip` so that it could use Web Worker if it, this is not possible when `zipAsync` because it the async version is on has to be on the main thread