### PR TITLE
fix: Allow spaces to be placed in SharedStrings file

### DIFF
--- a/packages/excel-builder-vanilla/src/Excel/SharedStrings.ts
+++ b/packages/excel-builder-vanilla/src/Excel/SharedStrings.ts
@@ -42,6 +42,9 @@ export class SharedStrings {
 
     while (l--) {
       const clone = template.cloneNode(true);
+      if (strings[l]?.match(/\s+/)) {
+        clone.firstChild!.setAttribute('xml:space', 'preserve');
+      }
       clone.firstChild!.firstChild!.nodeValue = strings[l];
       sharedStringTable.appendChild(clone);
     }


### PR DESCRIPTION
ref, original lib PR: https://github.com/stephenliberty/excel-builder.js/pull/83