### PR TITLE
feat: add `downloadExcelFile()` method for easier browser download

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,7 @@
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
-      "args": ["run", "${relativeFile}", "--pool", "forks", "--no-watch"],
+      "args": ["run", "${relativeFile}", "--pool", "forks", "--no-watch", "--config", "./vitest/vitest.config.mts"],
       "smartStep": true,
       "console": "integratedTerminal"
     }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@vitest/coverage-v8": "^1.2.2",
     "conventional-changelog-conventionalcommits": "^7.0.2",
     "cross-env": "^7.0.3",
+    "happy-dom": "^13.3.8",
     "npm-run-all2": "^6.1.2",
     "pnpm": "^8.15.0",
     "rimraf": "^5.0.5",

--- a/packages/demo/src/examples/demoUtils.ts
+++ b/packages/demo/src/examples/demoUtils.ts
@@ -34,29 +34,3 @@ export function buildHtmlTable(originalData: any[]) {
 
   return tableElm;
 }
-
-export function downloader(options: { filename: string; blob: Blob; data: any[] }) {
-  // when using IE/Edge, then use different download call
-  if (typeof (navigator as any).msSaveOrOpenBlob === 'function') {
-    (navigator as any).msSaveOrOpenBlob(options.blob, options.filename);
-  } else {
-    // this trick will generate a temp <a /> tag
-    // the code will then trigger a hidden click for it to start downloading
-    const link = document.createElement('a');
-    const url = URL.createObjectURL(options.blob);
-
-    if (link && document) {
-      link.textContent = 'download';
-      link.href = url;
-      link.setAttribute('download', options.filename);
-
-      // set the visibility to hidden so there is no effect on your web-layout
-      link.style.visibility = 'hidden';
-
-      // this part will append the anchor tag, trigger a click (for download to start) and finally remove the tag once completed
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    }
-  }
-}

--- a/packages/demo/src/examples/example01.ts
+++ b/packages/demo/src/examples/example01.ts
@@ -1,6 +1,6 @@
-import { Workbook, createExcelFile } from 'excel-builder-vanilla';
+import { Workbook, downloadExcelFile } from 'excel-builder-vanilla';
 
-import { buildHtmlTable, downloader } from './demoUtils';
+import { buildHtmlTable } from './demoUtils';
 import './example01.scss';
 
 export default class Example {
@@ -34,14 +34,6 @@ export default class Example {
     albumList.setData(this.originalData);
     artistWorkbook.addWorksheet(albumList);
 
-    createExcelFile(artistWorkbook).then(excelBlob => {
-      const downloadOptions = {
-        filename: 'Artist WB.xlsx',
-        format: 'xlsx',
-      };
-
-      // start downloading but add the Blob property only on the start download not on the event itself
-      downloader({ ...downloadOptions, blob: excelBlob, data: albumList.data });
-    });
+    downloadExcelFile(artistWorkbook, 'Artist WB.xlsx');
   }
 }

--- a/packages/demo/src/examples/example02.ts
+++ b/packages/demo/src/examples/example02.ts
@@ -1,6 +1,5 @@
-import { createExcelFile, createWorkbook } from 'excel-builder-vanilla';
+import { createWorkbook, downloadExcelFile } from 'excel-builder-vanilla';
 
-import { downloader } from './demoUtils';
 import './example02.scss';
 
 export default class Example {
@@ -34,14 +33,6 @@ export default class Example {
 
     artistWorkbook.addWorksheet(albumList);
 
-    createExcelFile(artistWorkbook).then(excelBlob => {
-      const downloadOptions = {
-        filename: 'Artist WB.xlsx',
-        format: 'xlsx',
-      };
-
-      // start downloading but add the Blob property only on the start download not on the event itself
-      downloader({ ...downloadOptions, blob: excelBlob, data: albumList.data });
-    });
+    downloadExcelFile(artistWorkbook, 'Artist WB.xlsx');
   }
 }

--- a/packages/demo/src/examples/example03.ts
+++ b/packages/demo/src/examples/example03.ts
@@ -1,6 +1,6 @@
-import { createExcelFile, createWorkbook } from 'excel-builder-vanilla';
+import { createWorkbook, downloadExcelFile } from 'excel-builder-vanilla';
 
-import { buildHtmlTable, downloader } from './demoUtils';
+import { buildHtmlTable } from './demoUtils';
 import './example03.scss';
 
 export default class Example {
@@ -50,14 +50,6 @@ export default class Example {
 
     artistWorkbook.addWorksheet(albumList);
 
-    createExcelFile(artistWorkbook).then(excelBlob => {
-      const downloadOptions = {
-        filename: 'Artist WB.xlsx',
-        format: 'xlsx',
-      };
-
-      // start downloading but add the Blob property only on the start download not on the event itself
-      downloader({ ...downloadOptions, blob: excelBlob, data: albumList.data });
-    });
+    downloadExcelFile(artistWorkbook, 'Artist WB.xlsx');
   }
 }

--- a/packages/demo/src/examples/example04.ts
+++ b/packages/demo/src/examples/example04.ts
@@ -1,6 +1,5 @@
-import { createExcelFile, createWorkbook } from 'excel-builder-vanilla';
+import { createWorkbook, downloadExcelFile } from 'excel-builder-vanilla';
 
-import { downloader } from './demoUtils';
 import './example04.scss';
 
 export default class Example {
@@ -61,14 +60,6 @@ export default class Example {
 
     artistWorkbook.addWorksheet(albumList);
 
-    createExcelFile(artistWorkbook).then(excelBlob => {
-      const downloadOptions = {
-        filename: 'Artist WB.xlsx',
-        format: 'xlsx',
-      };
-
-      // start downloading but add the Blob property only on the start download not on the event itself
-      downloader({ ...downloadOptions, blob: excelBlob, data: albumList.data });
-    });
+    downloadExcelFile(artistWorkbook, 'Artist WB.xlsx');
   }
 }

--- a/packages/demo/src/examples/example05.ts
+++ b/packages/demo/src/examples/example05.ts
@@ -1,6 +1,5 @@
-import { createExcelFile, createWorkbook } from 'excel-builder-vanilla';
+import { createWorkbook, downloadExcelFile } from 'excel-builder-vanilla';
 
-import { downloader } from './demoUtils';
 import './example05.scss';
 
 export default class Example {
@@ -74,14 +73,6 @@ export default class Example {
     albumList.setColumns([{ width: 15 }, { width: 15 }, { width: 15 }, { width: 15 }]);
     artistWorkbook.addWorksheet(albumList);
 
-    createExcelFile(artistWorkbook).then(excelBlob => {
-      const downloadOptions = {
-        filename: 'Artist WB.xlsx',
-        format: 'xlsx',
-      };
-
-      // start downloading but add the Blob property only on the start download not on the event itself
-      downloader({ ...downloadOptions, blob: excelBlob, data: albumList.data });
-    });
+    downloadExcelFile(artistWorkbook, 'Artist WB.xlsx');
   }
 }

--- a/packages/demo/src/examples/example06.ts
+++ b/packages/demo/src/examples/example06.ts
@@ -1,6 +1,5 @@
-import { createExcelFile, createWorkbook } from 'excel-builder-vanilla';
+import { createWorkbook, downloadExcelFile } from 'excel-builder-vanilla';
 
-import { downloader } from './demoUtils';
 import './example06.scss';
 
 export default class Example {
@@ -45,14 +44,6 @@ export default class Example {
 
     artistWorkbook.addWorksheet(albumList);
 
-    createExcelFile(artistWorkbook).then(excelBlob => {
-      const downloadOptions = {
-        filename: 'Artist WB.xlsx',
-        format: 'xlsx',
-      };
-
-      // start downloading but add the Blob property only on the start download not on the event itself
-      downloader({ ...downloadOptions, blob: excelBlob, data: albumList.data });
-    });
+    downloadExcelFile(artistWorkbook, 'Artist WB.xlsx');
   }
 }

--- a/packages/demo/src/examples/example07.ts
+++ b/packages/demo/src/examples/example07.ts
@@ -1,6 +1,5 @@
-import { createExcelFile, createWorkbook } from 'excel-builder-vanilla';
+import { createWorkbook, downloadExcelFile } from 'excel-builder-vanilla';
 
-import { downloader } from './demoUtils';
 import './example07.scss';
 
 export default class Example {
@@ -65,14 +64,6 @@ export default class Example {
 
     artistWorkbook.addWorksheet(albumList);
 
-    createExcelFile(artistWorkbook).then(excelBlob => {
-      const downloadOptions = {
-        filename: 'Artist WB.xlsx',
-        format: 'xlsx',
-      };
-
-      // start downloading but add the Blob property only on the start download not on the event itself
-      downloader({ ...downloadOptions, blob: excelBlob, data: albumList.data });
-    });
+    downloadExcelFile(artistWorkbook, 'Artist WB.xlsx');
   }
 }

--- a/packages/demo/src/examples/example08.ts
+++ b/packages/demo/src/examples/example08.ts
@@ -1,6 +1,5 @@
-import { createExcelFile, createWorkbook } from 'excel-builder-vanilla';
+import { createWorkbook, downloadExcelFile } from 'excel-builder-vanilla';
 
-import { downloader } from './demoUtils';
 import './example08.scss';
 
 export default class Example {
@@ -35,14 +34,6 @@ export default class Example {
 
     artistWorkbook.addWorksheet(albumList);
 
-    createExcelFile(artistWorkbook).then(excelBlob => {
-      const downloadOptions = {
-        filename: 'Artist WB.xlsx',
-        format: 'xlsx',
-      };
-
-      // start downloading but add the Blob property only on the start download not on the event itself
-      downloader({ ...downloadOptions, blob: excelBlob, data: albumList.data });
-    });
+    downloadExcelFile(artistWorkbook, 'Artist WB.xlsx');
   }
 }

--- a/packages/demo/src/examples/example09.ts
+++ b/packages/demo/src/examples/example09.ts
@@ -1,6 +1,5 @@
-import { Table, createExcelFile, createWorkbook } from 'excel-builder-vanilla';
+import { Table, createWorkbook, downloadExcelFile } from 'excel-builder-vanilla';
 
-import { downloader } from './demoUtils';
 import './example09.scss';
 
 export default class Example {
@@ -45,14 +44,6 @@ export default class Example {
     albumList.addTable(albumTable);
     artistWorkbook.addTable(albumTable);
 
-    createExcelFile(artistWorkbook).then(excelBlob => {
-      const downloadOptions = {
-        filename: 'Artist WB.xlsx',
-        format: 'xlsx',
-      };
-
-      // start downloading but add the Blob property only on the start download not on the event itself
-      downloader({ ...downloadOptions, blob: excelBlob, data: albumList.data });
-    });
+    downloadExcelFile(artistWorkbook, 'Artist WB.xlsx');
   }
 }

--- a/packages/demo/src/examples/example10.ts
+++ b/packages/demo/src/examples/example10.ts
@@ -1,6 +1,5 @@
-import { Table, createExcelFile, createWorkbook } from 'excel-builder-vanilla';
+import { Table, createWorkbook, downloadExcelFile } from 'excel-builder-vanilla';
 
-import { downloader } from './demoUtils';
 import './example10.scss';
 
 export default class Example {
@@ -60,14 +59,6 @@ export default class Example {
     albumList.addTable(albumTable);
     artistWorkbook.addTable(albumTable);
 
-    createExcelFile(artistWorkbook).then(excelBlob => {
-      const downloadOptions = {
-        filename: 'Artist WB.xlsx',
-        format: 'xlsx',
-      };
-
-      // start downloading but add the Blob property only on the start download not on the event itself
-      downloader({ ...downloadOptions, blob: excelBlob, data: albumList.data });
-    });
+    downloadExcelFile(artistWorkbook, 'Artist WB.xlsx');
   }
 }

--- a/packages/demo/src/examples/example11.ts
+++ b/packages/demo/src/examples/example11.ts
@@ -1,6 +1,5 @@
-import { Table, createExcelFile, createWorkbook } from 'excel-builder-vanilla';
+import { Table, createWorkbook, downloadExcelFile } from 'excel-builder-vanilla';
 
-import { downloader } from './demoUtils';
 import './example11.scss';
 
 export default class Example {
@@ -51,14 +50,6 @@ export default class Example {
     albumList.addTable(albumTable);
     artistWorkbook.addTable(albumTable);
 
-    createExcelFile(artistWorkbook).then(excelBlob => {
-      const downloadOptions = {
-        filename: 'Artist WB.xlsx',
-        format: 'xlsx',
-      };
-
-      // start downloading but add the Blob property only on the start download not on the event itself
-      downloader({ ...downloadOptions, blob: excelBlob, data: albumList.data });
-    });
+    downloadExcelFile(artistWorkbook, 'Artist WB.xlsx');
   }
 }

--- a/packages/demo/src/examples/example12.ts
+++ b/packages/demo/src/examples/example12.ts
@@ -1,6 +1,5 @@
-import { createExcelFile, createWorkbook } from 'excel-builder-vanilla';
+import { createWorkbook, downloadExcelFile } from 'excel-builder-vanilla';
 
-import { downloader } from './demoUtils';
 import './example12.scss';
 
 export default class Example {
@@ -41,14 +40,6 @@ export default class Example {
     albumList.setFooter(['Date of print: &D &T', '&A', 'Page &P of &N']);
     artistWorkbook.addWorksheet(albumList);
 
-    createExcelFile(artistWorkbook).then(excelBlob => {
-      const downloadOptions = {
-        filename: 'Artist WB.xlsx',
-        format: 'xlsx',
-      };
-
-      // start downloading but add the Blob property only on the start download not on the event itself
-      downloader({ ...downloadOptions, blob: excelBlob, data: albumList.data });
-    });
+    downloadExcelFile(artistWorkbook, 'Artist WB.xlsx');
   }
 }

--- a/packages/excel-builder-vanilla/src/__tests__/factory.spec.ts
+++ b/packages/excel-builder-vanilla/src/__tests__/factory.spec.ts
@@ -1,9 +1,7 @@
-import { strFromU8, zip } from 'fflate';
-import { beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { strFromU8 } from 'fflate';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createExcelFile, createWorkbook } from '../factory';
-
-// vi.mock('fflate');
+import { createExcelFile, createWorkbook, downloadExcelFile } from '../factory';
 
 describe('ExcelExportService', () => {
   let mockExcelBlob: Blob;
@@ -11,8 +9,7 @@ describe('ExcelExportService', () => {
 
   describe('with Translater Service', () => {
     beforeEach(() => {
-      // (navigator as any).__defineGetter__('appName', () => 'Netscape');
-      // (navigator as any).msSaveOrOpenBlob = undefined as any;
+      (navigator as any).__defineGetter__('appName', () => 'Netscape');
       mockExcelBlob = new Blob(['', ''], { type: 'text/xlsx;charset=utf-8;' });
       uint = new Uint8Array([21, 31]);
     });
@@ -35,6 +32,28 @@ describe('ExcelExportService', () => {
         expect(file).toBeTruthy();
         expect(file instanceof Uint8Array).toBeTruthy();
         expect(output).includes('workbook.xml');
+      });
+    });
+
+    describe('downloadExcelFile() method', () => {
+      it('should be able to download Excel file via browser', async () => {
+        const createUrlSpy = vi.spyOn(URL, 'createObjectURL');
+        const revokeUrlSpy = vi.spyOn(URL, 'createObjectURL');
+        const anchorSpy = vi.spyOn(document, 'createElement');
+
+        const workbook = createWorkbook();
+        await downloadExcelFile(workbook, 'export.xlsx');
+
+        expect(anchorSpy).toHaveBeenCalled();
+        expect(createUrlSpy).toHaveBeenCalled();
+        expect(revokeUrlSpy).toHaveBeenCalled();
+      });
+
+      it('throws when trying different downloadType other than browser', async () => {
+        const workbook = createWorkbook();
+        const promise = downloadExcelFile(workbook, 'export.xlsx', 'node');
+
+        await expect(promise).rejects.toThrow();
       });
     });
   });

--- a/packages/excel-builder-vanilla/src/factory.ts
+++ b/packages/excel-builder-vanilla/src/factory.ts
@@ -54,3 +54,49 @@ export function createExcelFile<T extends 'Blob' | 'Uint8Array' = 'Blob'>(
     });
   });
 }
+
+/**
+ * Download Excel file, currently only supports a "browser" as `downloadType`
+ * but it could be expended in the future to also other type of platform like NodeJS for example.
+ * @param options
+ */
+export function downloadExcelFile(workbook: Workbook, filename: string, downloadType: 'browser' | 'node' = 'browser') {
+  // start downloading but add the Blob property only on the download start instead of the event itself
+  // Note: we call the Promise with `.then()` for perf reason since `fflate.zip` can use Web Worker but `fflate.zipAsync` cannot
+  return createExcelFile(workbook).then(excelBlob => {
+    downloadFile(filename, excelBlob, downloadType);
+  });
+}
+
+/**
+ * Download Excel file, currently only supports a "browser" as `downloadType`,
+ * but it could probably be expended to support other platform in the future like NodeJS for example.
+ * @param options
+ */
+function downloadFile(filename: string, data: Blob, downloadType: 'browser' | 'node' = 'browser') {
+  if (downloadType === 'browser') {
+    // this trick will generate a temp <a /> tag
+    // the code will then trigger a hidden click for it to start downloading
+    const link = document.createElement('a');
+    const url = URL.createObjectURL(data);
+
+    if (link && document) {
+      link.textContent = 'download';
+      link.href = url;
+      link.setAttribute('download', filename);
+
+      // set the visibility to hidden so there is no effect on your web-layout
+      link.style.visibility = 'hidden';
+
+      // this part will append the anchor tag, trigger a click (for download to start) and finally remove the tag once completed
+      document.body.appendChild(link);
+      link.click();
+
+      // we're done, let's delete the temp DOM element & revoke the URL object
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    }
+  } else {
+    throw new Error('[Excel-Builder-Vanilla] the `downloadExcelFile()` is only supporting the "browser" download type at the moment.');
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      happy-dom:
+        specifier: ^13.3.8
+        version: 13.3.8
       npm-run-all2:
         specifier: ^6.1.2
         version: 6.1.2
@@ -43,7 +46,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^1.2.2
-        version: 1.2.2(@types/node@20.11.16)
+        version: 1.2.2(@types/node@20.11.16)(happy-dom@13.3.8)
 
   packages/demo:
     dependencies:
@@ -1303,7 +1306,7 @@ packages:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.2.2(@types/node@20.11.16)
+      vitest: 1.2.2(@types/node@20.11.16)(happy-dom@13.3.8)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2474,6 +2477,15 @@ packages:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.17.4
+    dev: true
+
+  /happy-dom@13.3.8:
+    resolution: {integrity: sha512-RAbq4oYfJNkVan1m1F3jfA4YEyRY0/ASoNvZsNJbuX85jIypidmsz9jQZD7Tqz0VXA2MhAGfcsh5oshwmwNYSg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
     dev: true
 
   /has-flag@3.0.0:
@@ -4468,7 +4480,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.2.2(@types/node@20.11.16):
+  /vitest@1.2.2(@types/node@20.11.16)(happy-dom@13.3.8):
     resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -4504,6 +4516,7 @@ packages:
       chai: 4.4.1
       debug: 4.3.4
       execa: 8.0.1
+      happy-dom: 13.3.8
       local-pkg: 0.5.0
       magic-string: 0.30.6
       pathe: 1.1.2
@@ -4557,6 +4570,16 @@ packages:
   /web-streams-polyfill@3.3.2:
     resolution: {integrity: sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ==}
     engines: {node: '>= 8'}
+    dev: true
+
+  /webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
     dev: true
 
   /which@2.0.2:

--- a/vitest/vitest-pretest.ts
+++ b/vitest/vitest-pretest.ts
@@ -1,0 +1,2 @@
+// (global as any).Storage = window.localStorage;
+(global as any).navigator = { userAgent: 'node.js' };

--- a/vitest/vitest.config.mts
+++ b/vitest/vitest.config.mts
@@ -7,10 +7,8 @@ export default defineConfig({
     deps: {
       interopDefault: false,
     },
-    environment: 'node',
-    dangerouslyIgnoreUnhandledErrors: true, // useNx often fails and it's probably going to be removed in next major
-    testTimeout: 60000,
-    setupFiles: [],
+    environment: 'happy-dom',
+    setupFiles: ['./vitest/vitest-pretest.ts'],
     watch: false,
     coverage: {
       include: ['packages/excel-builder-vanilla/**/*.ts'],


### PR DESCRIPTION
- the `createExcelFile` still exists and can still be used by users if for example they want to download on other platform like NodeJS instead of a browser download
- currently the `downloadExcelFile()` method only supports a "browser" download type, but it could be extended in the future support other platforms like NodeJS